### PR TITLE
Deprecation fix for SF4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
     form.type.xmon_color_picker:
-        class: %form.type.xmon_color_picker.class%
+        class: "%form.type.xmon_color_picker.class%"
         tags:
             - { name: form.type, alias: xmon_color_picker }

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,17 @@
     },
     "autoload": {
         "psr-0": {
-            "Xmon\\ColorPickerTypeBundle": "" 
-            }
+            "Xmon\\ColorPickerTypeBundle": ""
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Xmon\\ColorPickerTypeBundleTests\\": "tests/"
+        }
     },
     "minimum-stability": "dev",
-    "target-dir": "Xmon/ColorPickerTypeBundle"
+    "target-dir": "Xmon/ColorPickerTypeBundle",
+    "require-dev": {
+        "phpunit/phpunit": "^6.5@dev"
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuite name="default">
+        <directory suffix="Test.php">tests</directory>
+    </testsuite>
+</phpunit>

--- a/tests/DependencyInjection/XmonColorPickerTypeExtensionTest.php
+++ b/tests/DependencyInjection/XmonColorPickerTypeExtensionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Xmon\ColorPickerTypeBundleTests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Xmon\ColorPickerTypeBundle\DependencyInjection\XmonColorPickerTypeExtension;
+use Xmon\ColorPickerTypeBundle\Form\Type\ColorPickerType;
+
+class XmonColorPickerTypeExtensionTest extends TestCase
+{
+    public function testDefaultConfigurationColorPickerClassIsLoaded()
+    {
+        $container = new ContainerBuilder();
+        
+        (new XmonColorPickerTypeExtension())->load([], $container);
+        
+        // Compile to resolve % substitutions in the configuration.
+        $container->compile();
+        
+        $this->assertSame(
+            ColorPickerType::class,
+            $container->getDefinition('form.type.xmon_color_picker')->getClass()
+        );
+    }
+}


### PR DESCRIPTION
Hi. This fixes the deprecation warning that is present for me in Symfony v3.3.13:

```
Not quoting the scalar "%form.type.xmon_color_picker.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/tmp/color-bundle-deprecation/vendor/xmon/color-picker-type-bundle/Xmon/ColorPickerTypeBundle/DependencyInjection/../Resources/config/services.yml" on line 6.
```

I have also added PHPUnit to validate the change.